### PR TITLE
update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
+dist: bionic
 php:
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 
 env:
   global:
-    - CORE_BRANCH=stable10
+    - CORE_BRANCH=master
   matrix:
   - DB=sqlite
 
@@ -15,12 +15,15 @@ branches:
   only:
     - master
 
-install:
+before_install:
+  - nvm install 8.15
   - wget https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh
   - bash ./before_install.sh twofactor_backup_codes $CORE_BRANCH $DB
   - make
   - make appstore
   - cd ../core
+  - composer install
+  - bash ./core_install.sh $DB
   - php occ app:enable twofactor_backup_codes
 
 script:
@@ -37,18 +40,12 @@ after_failure:
 
 matrix:
   include:
-    - php: 7.0
-      env: DB=mysql
-    - php: 7.1
+    - php: 7.3
+      services: mysql
       env: DB=mysql CORE_BRANCH=master
-    - php: 7.2
-      env: DB=mysql CORE_BRANCH=master
-    - php: 7.0
-      env: DB=pgsql
-    - php: 7.1
+    - php: 7.3
+      services: postgresql
       env: DB=pgsql CORE_BRANCH=master
-    - php: 7.2
-      env: DB=pgsql CORE_BRANCH=master
-  
+
   fast_finish: true
 

--- a/tests/Controller/SettingsControllerTest.php
+++ b/tests/Controller/SettingsControllerTest.php
@@ -35,7 +35,7 @@ class SettingsControllerTest extends TestCase {
     private $userSession;
     /** @var SettingsController */
     private $controller;
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
         $this->request = $this->getMockBuilder(IRequest::class)->getMock();
         $this->backup = $this->getMockBuilder(Backup::class)

--- a/tests/Db/BackupCodeMapperTest.php
+++ b/tests/Db/BackupCodeMapperTest.php
@@ -51,13 +51,13 @@ class BackupCodeMapperTest extends TestCase {
         return $dbEntity;
     }
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
         $this->db = \OC::$server->getDatabaseConnection();
         $this->mapper = \OC::$server->query(BackupCodeMapper::class);
         $this->resetDB();
     }
-    protected function tearDown() {
+    protected function tearDown(): void {
         parent::tearDown();
         $this->resetDB();
     }

--- a/tests/Provider/BackupProviderTest.php
+++ b/tests/Provider/BackupProviderTest.php
@@ -41,7 +41,7 @@ class BackupCodesProviderTest extends TestCase {
     private $appManager;
     /** @var BackupProvider */
     private $provider;
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
         $this->appName = "twofactor_backup_codes";
         $this->backupService = $this->createMock(Backup::class);

--- a/tests/Service/BackupTest.php
+++ b/tests/Service/BackupTest.php
@@ -37,7 +37,7 @@ class BackupCodeStorageTest extends TestCase {
     /** @var Backup */
     private $backupService;
 
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
         $this->mapper = $this->createMock(BackupCodeMapper::class);
         $this->random = $this->createMock(ISecureRandom::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,10 +25,6 @@ require_once __DIR__.'/../../../lib/base.php';
 
 OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib', true);
 
-if(!class_exists('PHPUnit_Framework_TestCase')) {
-    require_once('PHPUnit/Autoload.php');
-}
-
 OC_App::loadApp('twofactor_backup_codes');
 
 OC_Hook::clear();


### PR DESCRIPTION
Fix travis:

- `dist: bionic` = Ubuntu 18.04 (the default was 16.04 which is quite old now)
- `CORE_BRANCH=master` (stable10 is no longer current)
- install current needed `nvm`
- https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh is an old thing these days, something goes wrong wwhen it is trying to "make"  and then install ownCloud. Do `composer install` and then `bash ./core_install.sh $DB` as separate steps in Travis (no point spending time trying to sort out `before_install.sh` now)
- adjust the extra matrix entries for mysql and pgsql. On Travis with "bionic"  the database services need to be specified (they no longer start by default)
- adjust unit test code and bootstrap for the current PHPunit8