### PR TITLE
allow users to remove backup codes from UI

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -30,5 +30,10 @@ return [
             'url' => '/settings/generateBackupCodes',
             'verb' => 'POST'
         ],
+        [
+            'name' => 'settings#removeBackupCodes',
+            'url' => '/settings/removeBackupCodes',
+            'verb' => 'DELETE'
+        ],
     ]
 ];

--- a/js/settingsview.js
+++ b/js/settingsview.js
@@ -23,6 +23,7 @@
             + '	       <span>' + t('twofactor_backup_codes', 'You have {{remaining}} backup codes left can be used.') + '</span><br>'
             + '    {{/if}}'
             + '	   <button id="backup-generate-backup-codes" class="button">' + t('twofactor_backup_codes', 'Regenerate codes') + '</button>'
+            + '	   <button id="backup-remove-backup-codes" class="button">' + t('twofactor_backup_codes', 'Remove codes') + '</button>'
             + '{{/unless}}'
             + '</div>';
 
@@ -45,7 +46,8 @@
         _codes: undefined,
 
         events: {
-            'click #backup-generate-backup-codes': '_clickGenerateBackupCodes'
+            'click #backup-generate-backup-codes': '_clickGenerateBackupCodes',
+            'click #backup-remove-backup-codes': '_clickRemoveBackupCodes'
         },
 
         /**
@@ -88,16 +90,23 @@
             }.bind(this));
         },
         _clickGenerateBackupCodes: function () {
-            // Hide old codes
-            this._remaining = 0;
-            this.render();
-            $('#generate-backup-codes').addClass('icon-loading-small');
+            $('#backup-generate-backup-codes').addClass('icon-loading-small');
             var url = OC.generateUrl('/apps/twofactor_backup_codes/settings/generateBackupCodes');
             $.ajax(url, {
                 method: 'POST'
             }).done(function(data) {
                 this._remaining = data.remaining;
                 this._codes = data.codes;
+                this.render();
+            }.bind(this));
+        },
+        _clickRemoveBackupCodes: function () {
+            $('#backup-remove-backup-codes').addClass('icon-loading-small');
+            var url = OC.generateUrl('/apps/twofactor_backup_codes/settings/removeBackupCodes');
+            $.ajax(url, {
+                method: 'DELETE'
+            }).done(function() {
+                this._remaining = 0;
                 this.render();
             }.bind(this));
         },

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -70,4 +70,16 @@ class SettingsController extends Controller {
         ];
     }
 
+    /**
+     * @NoAdminRequired
+     * @return array
+     */
+    public function removeBackupCodes() {
+        $user = $this->userSession->getUser();
+        $this->backup->deleteBackupCodesByUser($user);
+        return [
+            'remaining' => 0
+        ];
+    }
+
 }

--- a/lib/Provider/BackupProvider.php
+++ b/lib/Provider/BackupProvider.php
@@ -45,7 +45,7 @@ class BackupProvider implements IProvider {
      * @param string $appName
      * @param Backup $backup
      * @param IL10N $l10n
-     * @param AppManager $appManage
+     * @param AppManager $appManager
      */
     public function __construct($appName, Backup $backup, IL10N $l10n, AppManager $appManager) {
         $this->appName = $appName;

--- a/tests/Controller/SettingsControllerTest.php
+++ b/tests/Controller/SettingsControllerTest.php
@@ -58,6 +58,7 @@ class SettingsControllerTest extends TestCase {
         ];
         $this->assertEquals($expected, $this->controller->state());
     }
+
     public function testGenerateBackupCodes() {
         $user = $this->getMockBuilder(IUser::class)->getMock();
         $codes = ['code1', 'code2'];
@@ -80,5 +81,19 @@ class SettingsControllerTest extends TestCase {
             'codes' => $codes,
         ];
         $this->assertEquals($expected, $this->controller->generateBackupCodes());
+    }
+
+    public function testRemoveBackupCodes() {
+        $user = $this->getMockBuilder(IUser::class)->getMock();
+        $this->userSession->expects($this->once())
+            ->method('getUser')
+            ->will($this->returnValue($user));
+        $this->backup->expects($this->once())
+            ->method('deleteBackupCodesByUser')
+            ->with($user);
+        $expected = [
+            'remaining' => 0
+        ];
+        $this->assertEquals($expected, $this->controller->removeBackupCodes());
     }
 }


### PR DESCRIPTION
Partially fixes https://github.com/owncloud/twofactor_backup_codes/issues/17

This pr adds a remove codes button to user app settings UI and allows users to remove backup codes from UI.
![resim](https://user-images.githubusercontent.com/14157973/98451559-d6876180-2157-11eb-9208-e4c712eb4923.png)
