### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,125 @@
-# Two Factor Backup Codes
-[![Build Status](https://travis-ci.org/owncloud/twofactor_backup_codes.svg?branch=master)](https://travis-ci.org/owncloud/twofactor_backup_codes)
+# Two-Factor Backup Codes
 
-Backup codes allow a user to recover from a loss of the second-factor device. 
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-![](https://raw.githubusercontent.com/owncloud/twofactor_backup_codes/717991de4a7d4ff634add9897867eeeed7662c7b/screenshots/verify.png)
+[![License](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
+
+Two-Factor Backup Codes provides a recovery mechanism for users who have enabled two-factor authentication on their ownCloud Server account. When a user loses access to their second-factor device (such as a phone with an authenticator app), backup codes allow them to regain access to their account by entering a one-time recovery code generated during the initial two-factor setup.
+
+## Part of Classic (OC10)
+
+This app is part of the [ownCloud Server (OC10)](https://github.com/owncloud/core) two-factor authentication ecosystem, working alongside [twofactor_totp](https://github.com/owncloud/twofactor_totp) to provide a complete 2FA solution with recovery capability.
+
+The ownCloud Server is available on [Docker Hub](https://hub.docker.com/r/owncloud/server).
+
+## Getting Started
+
+Follow the steps below to install and enable backup codes for two-factor authentication.
+
+### Installation
+
+Install from the ownCloud Marketplace, or manually:
+
+```bash
+cd apps
+git clone https://github.com/owncloud/twofactor_backup_codes.git
+cd ..
+php occ app:enable twofactor_backup_codes
+```
+
+### Building
+
+```bash
+make all                   # Install all dependencies
+make dist                  # Build distribution package
+```
+
+### Running Tests
+
+```bash
+make test-php-unit         # Run PHP unit tests
+make test-php-style        # Check code style
+make test-acceptance-api   # Run API acceptance tests
+```
+
+## Documentation
+
+- [ownCloud Server Admin Manual](https://doc.owncloud.com/server/latest/admin_manual/)
+- [Two-Factor Authentication Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/security_setup.html)
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/twofactor_backup_codes)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [GPL-3.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: GPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **Complete relicensing**: GPL-3.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,77 @@
+# agents.md — twofactor_backup_codes
+
+## Repository Overview
+
+An ownCloud Server (OC10) app providing backup recovery codes for two-factor authentication. Allows users to recover account access when they lose their second-factor device.
+
+- **Classification:** Classic (OC10)
+- **Activity Status:** Active
+- **License:** GPL-3.0
+- **Language:** PHP, JavaScript (Starlark listed for CI)
+
+## Architecture & Key Paths
+
+- `appinfo/` — ownCloud app metadata (info.xml, routes)
+- `lib/` — PHP backend (backup code generation, verification)
+- `js/` — Frontend JavaScript
+- `l10n/` — Localization/translation files
+- `templates/` — PHP templates for UI
+- `screenshots/` — UI screenshots
+- `tests/` — PHPUnit test suites
+- `Makefile` — Build and test orchestration
+- `composer.json` — PHP dependencies
+- `phpunit.xml` — PHPUnit configuration
+
+## Development Conventions
+
+- Standard ownCloud OC10 app structure
+- Code style enforced by phpcs
+- GitHub Actions CI
+
+## Build & Test Commands
+
+```bash
+make all                    # Install all dependencies
+make dist                   # Build distribution package
+make clean                  # Clean build artifacts
+make test-php-unit          # Run PHP unit tests
+make test-php-style         # Check code style
+make test-php-style-fix     # Auto-fix style issues
+make test-php-phan          # Run Phan static analysis
+make test-php-phpstan       # Run PHPStan static analysis
+make test-acceptance-api    # Run API acceptance tests
+make test-acceptance-cli    # Run CLI acceptance tests
+make test-acceptance-webui  # Run webUI acceptance tests
+```
+
+## Important Constraints
+
+- **GPL-3.0 copyleft license:** This repository is GPL-3.0. The OSPO Apache 2.0 migration requires auditing copyleft dependencies and contributor agreements.
+- **Companion app:** Works alongside `twofactor_totp` for a complete 2FA solution.
+- **Security-sensitive:** Handles authentication recovery codes -- changes must be carefully reviewed.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+- This is an ownCloud Server (OC10) app, not an oCIS extension.
+- The `lib/` directory contains backup code generation and verification logic.
+- The `l10n/` directory contains translations for the UI.
+- Works in conjunction with the `twofactor_totp` app.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>